### PR TITLE
docs: translate README.md from Korean to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Timer Pomodoro
 
-> CLI 기반 뽀모도로 타이머 (Node.js) — 시스템 알림과 사운드 알림을 지원합니다.
+> A simple CLI-based Pomodoro Timer (Node.js) with system notifications and sound alerts.
 
 ## Feature
 
-- 작업 세션 수 추적
-- 최대 세션(기본 4회) 도달 시 장기 휴식 자동 적용
-- 시스템 팝업 알림 (node-notifier) + 사운드 알림
-- 카운트다운/휴식 전환 시 알림 메시지 (한국어)
-- Ctrl+C로 언제든지 타이머 종료 가능
+- Track the number of work sessions
+- Automatic long break after reaching the max session count (default: 4)
+- System popup notifications (node-notifier) + sound alerts
+- Notification messages in Korean at countdown/break transitions
+- Graceful termination with Ctrl+C at any time
 
 ## Table of Contents
 
@@ -25,7 +25,7 @@
 $ npm install -g timer-pomodoro
 ```
 
-또는 소스코드에서 직접 설치:
+Or install from source:
 
 ```sh
 $ git clone https://github.com/kenshin579/timer-pomodoro
@@ -35,7 +35,7 @@ $ npm install
 
 ## Usage
 
-`timer-pomodoro`를 입력하면 도움말을 확인할 수 있습니다:
+Type `timer-pomodoro` to see the help usage:
 
 ```sh
 $ timer-pomodoro
@@ -58,12 +58,12 @@ Examples:
   $ timer-pomodoro -t 25 -b 10 -s 5: start 25 mins countdown timer and take 10 mins break (repeats 5 times)
 ```
 
-25분 작업 + 5분 휴식 타이머 시작:
+Start a 25-minute work timer with a 5-minute break:
 ```sh
 $ timer-pomodoro -t 25 -b 5
 ```
 
-20분 작업 타이머만 시작:
+Start a 20-minute work timer only:
 ```sh
 $ timer-pomodoro -t 20
 ```
@@ -71,20 +71,20 @@ $ timer-pomodoro -t 20
 ## Development
 
 ```bash
-npm install                # 의존성 설치
+npm install                # Install dependencies
 npm run compile            # Babel ES6→ES5: src/ → lib/
-npm run compile:watch      # 파일 변경 감지 컴파일
-npm start                  # 컴파일된 앱 실행 (lib/app.js)
-npm test                   # Jest 테스트 실행
-npm run lint               # Standard.js 린트 (--fix)
-npm run coverage           # 커버리지 리포트
+npm run compile:watch      # Compile with file watching
+npm start                  # Run compiled app (lib/app.js)
+npm test                   # Run Jest tests
+npm run lint               # Standard.js linter with --fix
+npm run coverage           # Coverage report
 npm run release:patch      # lint + compile + version bump + publish
 ```
 
 ## Todo
 
-- [ ] 팝업 메시지 다국어 지원 (현재 한국어만 지원)
-- [ ] 타이머 표시 옵션 추가 (예: 큰 폰트)
+- [ ] Localize popup messages (currently Korean only)
+- [ ] Add display options for timer (e.g. larger font)
 
 ## References
 


### PR DESCRIPTION
## Summary

- Translate all Korean text in README.md to English
- Includes: project description, features, install instructions, usage examples, development commands, and todo items

## Test plan

- [ ] Verify README.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)